### PR TITLE
[Mission 07] 한입-씨네마 SSG 적용하기 (with 데이터 페칭)

### DIFF
--- a/apps/web-page/src/components/global-layout.tsx
+++ b/apps/web-page/src/components/global-layout.tsx
@@ -1,5 +1,5 @@
-import style from "./global-layout.module.css";
 import Link from "next/link";
+import style from "./global-layout.module.css";
 
 export const GlobalLayout = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/apps/web-page/src/pages/movie/[id]/index.tsx
+++ b/apps/web-page/src/pages/movie/[id]/index.tsx
@@ -1,17 +1,28 @@
 import { useRouter } from "next/router";
-import { getMovie } from "@/lib/api/movie";
+import { getAllMovies, getMovie } from "@/lib/api/movie";
 import styles from "./index.module.css";
 
 import type {
-  GetServerSidePropsContext,
-  InferGetServerSidePropsType,
+  GetStaticPropsContext,
+  InferGetStaticPropsType,
 } from "next/types";
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
+export async function getStaticPaths() {
+  const movies = await getAllMovies();
+
+  return {
+    paths: movies.map(({ id }) => ({
+      params: { id: id.toString() },
+    })),
+    fallback: true,
+  };
+}
+
+export async function getStaticProps(context: GetStaticPropsContext) {
   const id = context.params!.id;
   const movie = await getMovie(Number(id));
 
-  if (movie === null) return { notFound: true };
+  if (!movie) return { notFound: true };
 
   return {
     props: { movie },
@@ -20,7 +31,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
 export default function MoviePage({
   movie,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const router = useRouter();
 
   if (router.isFallback) return "Loading...";

--- a/apps/web-page/src/pages/search/index.tsx
+++ b/apps/web-page/src/pages/search/index.tsx
@@ -1,28 +1,30 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import { MovieItem } from "@/components/movie-item";
 import { SearchableLayout } from "@/components/searchable-layout";
 import { searchMovie } from "@/lib/api/movie";
 import styles from "./index.module.css";
 
-import type {
-  GetServerSidePropsContext,
-  InferGetServerSidePropsType,
-} from "next/types";
+import type { Movie } from "@/types";
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const { q } = context.query;
-  const movies = await searchMovie(q as string);
+export default function SearchPage() {
+  const router = useRouter();
+  const q = router.query.q as string;
 
-  return {
-    props: { movies },
-  };
-}
+  const [searchedMovies, setSearchedMovies] = useState<Array<Movie>>([]);
 
-export default function SearchPage({
-  movies,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  useEffect(() => {
+    if (!q) return;
+
+    (async () => {
+      const movies = await searchMovie(q);
+      setSearchedMovies(movies);
+    })();
+  }, [q]);
+
   return (
     <div className={styles.container}>
-      {movies.map((movie) => (
+      {searchedMovies.map((movie) => (
         <MovieItem key={movie.id} movie={movie} />
       ))}
     </div>


### PR DESCRIPTION
- Home 페이지 => SSG: 추천 영화는 주로 갱신 주기가 긴 서비스라고 생각해서 SSG 적용하고 이후 무효화로 갱신하는 게 좋을 것이라 생각함.
- Search 페이지 => CSR: 검색 결과는 경우의 수가 너무 다양하기 때문에 검색 결과를 매번 서버에서 렌더링하면 부하가 심할 것으로 예상함.
- Movie 페이지 => SSG: 각 영화의 상세 데이터는 자주 바뀌지 않을 거라 생각해서 SSG로 생성함.